### PR TITLE
Update zilswap SDK and improve error strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "uuid": "^3.3.3",
     "validate.js": "^0.13.1",
     "xlsx": "^0.15.5",
-    "zilswap-sdk": "^0.0.17"
+    "zilswap-sdk": "^0.0.18"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/app/layouts/WalletDialog/components/ConnectWalletZilPay/ConnectWalletZilPay.tsx
+++ b/src/app/layouts/WalletDialog/components/ConnectWalletZilPay/ConnectWalletZilPay.tsx
@@ -77,7 +77,7 @@ const ConnectWalletZilPay: React.FC<ConnectWalletManagerViewProps> = (props: any
 
       const result = await zilPay.wallet.connect();
       if (result !== zilPay.wallet.isConnect)
-        throw new Error("ZilPay could not connect.");
+        throw new Error("ZilPay could not be connected to.");
 
       const walletResult: ConnectWalletResult = await connectWalletZilPay(zilPay);
       if (walletResult.error)

--- a/src/core/wallet/wallet.ts
+++ b/src/core/wallet/wallet.ts
@@ -44,6 +44,7 @@ export const connectWalletPrivateKey = async (inputPrivateKey: string, network: 
 
   return { wallet };
 };
+
 export const connectWalletZilPay = async (zilPay: any): Promise<ConnectWalletResult> => {
 
   if (!zilPay.wallet.isConnect)
@@ -56,7 +57,8 @@ export const connectWalletZilPay = async (zilPay: any): Promise<ConnectWalletRes
 
   const network = zilPay.wallet.net === Network.TestNet.toLowerCase() ? Network.TestNet : Network.MainNet;
   if (network === Network.MainNet)
-    throw new Error("MainNet is not supported yet");
+    throw new Error("MainNet is not supported yet. Please select 'TestNet' within ZilPay.");
+
   const wallet = new ZilPayConnectedWallet({
     network, timestamp,
     zilpay: zilPay as WalletProvider,

--- a/src/core/zilswap/connector.ts
+++ b/src/core/zilswap/connector.ts
@@ -61,7 +61,7 @@ type StateUpdateProps = {
 /**
  * Checks transaction receipt for error, and throw the top level exception
  * if any.
- * 
+ *
  * @param txReceipt `@zilliqa-js` blockchain transaction receipt
  */
 const handleObservedTx = (observedTx: ObservedTx) => {
@@ -74,7 +74,7 @@ const handleObservedTx = (observedTx: ObservedTx) => {
 
 /**
  * Abstraction class for Zilswap SDK.
- * 
+ *
  * @member network {@link Zilswap.Network}
  */
 export class ZilswapConnector {
@@ -94,9 +94,9 @@ export class ZilswapConnector {
   };
 
   /**
-   * Constructor for Zilswap SDK wrapper. Must populate connectorState.wallet if executed, 
-   * throws error otherwise. 
-   * 
+   * Constructor for Zilswap SDK wrapper. Must populate connectorState.wallet if executed,
+   * throws error otherwise.
+   *
    * @param wallet `ConnectedWallet` instance to provide blockchain connection interface.
    * @returns Promise<Zilswap> Zilswap instance initialized with wallet properties (network and provider).
    * @throws "moonlet support under development" when providing MoonletConnectedWallet.
@@ -150,8 +150,8 @@ export class ZilswapConnector {
 
 
   /**
-   * 
-   * 
+   *
+   *
    */
   static registerObserver = (observer: OnUpdate | null) => {
     console.log("connector register observer");
@@ -166,7 +166,7 @@ export class ZilswapConnector {
   };
 
   /**
-   * 
+   *
    */
   static connect = async (props: ConnectProps) => {
     await ZilswapConnector.initializeForWallet(props);
@@ -175,7 +175,7 @@ export class ZilswapConnector {
 
   /**
    * Get a fresh instance of Zilliqa with the connector's network.
-   * 
+   *
    * @returns Zilliqa instance
    * @throws "not connected" if `ZilswapConnector.connect` not called.
    */
@@ -186,7 +186,7 @@ export class ZilswapConnector {
 
   /**
    * Get the app state of the Zilswap SDK.
-   * 
+   *
    * @returns the app state
    * @throws "not connected" if `ZilswapConnector.connect` not called.
    */
@@ -197,7 +197,7 @@ export class ZilswapConnector {
 
   /**
    * Get list of tokens found in the Zilswap SDK app state.
-   * 
+   *
    * @returns array of tokens in Zilswap SDK's TokenDetails representation.
    * @throws "not connected" if `ZilswapConnector.connect` not called.
    */
@@ -211,7 +211,7 @@ export class ZilswapConnector {
   /**
    * Get the pool of the provided token, or `null` if pool does not yet
    * exist on the contract.
-   * 
+   *
    * @returns the pool instance
    * @throws "not connected" if `ZilswapConnector.connect` not called.
    */
@@ -221,8 +221,8 @@ export class ZilswapConnector {
   };
 
   /**
-   * 
-   * 
+   *
+   *
    * @throws "not connected" if `ZilswapConnector.connect` not called.
    */
   static setDeadlineBlocks = (blocks: number) => {
@@ -231,7 +231,7 @@ export class ZilswapConnector {
   };
 
   /**
-   * 
+   *
    * @throws "not connected" if `ZilswapConnector.connect` not called.
    */
   static approveTokenTransfer = async (props: ApproveTxProps) => {
@@ -247,8 +247,8 @@ export class ZilswapConnector {
   };
 
   /**
-   * 
-   * 
+   *
+   *
    * @throws "not connected" if `ZilswapConnector.connect` not called.
    */
   static getExchangeRate = (props: ExchangeRateQueryProps) => {
@@ -268,13 +268,13 @@ export class ZilswapConnector {
   /**
    * Abstraction for Zilswap SDK functions
    * `addLiquidity`
-   * 
+   *
    * @param tokenID string
    * @param zilAmount BigNumber
    * @param tokenAmount BigNumber
    * @param maxExchangeRateChange number?
    * @see zilswap-sdk documentation
-   * 
+   *
    * @throws "not connected" if `ZilswapConnector.connect` not called.
    */
   static addLiquidity = async (props: AddLiquidityProps) => {
@@ -297,12 +297,12 @@ export class ZilswapConnector {
   /**
    * Abstraction for Zilswap SDK functions
    * `removeLiquidity`
-   * 
+   *
    * @param tokenID string
    * @param contributionAmount BigNumber
    * @param maxExchangeRateChange number?
    * @see zilswap-sdk documentation
-   * 
+   *
    * @throws "not connected" if `ZilswapConnector.connect` not called.
    */
   static removeLiquidity = async (props: RemoveLiquidityProps) => {
@@ -323,17 +323,17 @@ export class ZilswapConnector {
   /**
    * Abstraction for Zilswap SDK functions
    * `swapWithExactInput` and `swapWithExactOutput`
-   * 
+   *
    * "in" refers to the transfer of value *into* Zilswap contract
    * "out" refers to the transfer of value *out* of Zilswap contract
-   * 
+   *
    * @param exactOf  "in" | "out" - used to determine with exact swap function to use.
    * @param tokenInID string
    * @param tokenOutID string
    * @param amount BigNumber
    * @param maxAdditionalSlippage number?
    * @see zilswap-sdk documentation
-   * 
+   *
    * @throws "not connected" if `ZilswapConnector.connect` not called.
    */
   static swap = async (props: SwapProps) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12547,10 +12547,10 @@ yargs@^7.0.0:
     y18n "^3.2.1"
     yargs-parser "^5.0.0"
 
-zilswap-sdk@^0.0.17:
-  version "0.0.17"
-  resolved "https://registry.yarnpkg.com/zilswap-sdk/-/zilswap-sdk-0.0.17.tgz#f050367302bd4ebc0b867df94499afdf5a050a6b"
-  integrity sha512-8LxUMQIf9yiqHeZ1TiICDbgjlUyU8wxAxYKfMqn14yTzySKnHw+35zfEkLjbH1FaB05KPF6Y6//cZLOp1u+KCw==
+zilswap-sdk@^0.0.18:
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/zilswap-sdk/-/zilswap-sdk-0.0.18.tgz#9f3dea9f7aa7a06757571451fae370ad6aa38040"
+  integrity sha512-FrIBUpMm7Lwg158VOm5gBYif+oOjTxLQGt+15eFNiWeXdpxSON33DvF6IizIYuWecxIhcZQOLPiQoaWP2gqJDg==
   dependencies:
     "@zilliqa-js/zilliqa" "^0.10.1"
     async-mutex "^0.2.2"


### PR DESCRIPTION
- Updates Zilswap SDK to 0.0.18 to fix 0 ZIL (new account) issues
- Improve temporary error string for MainNet
