### PR TITLE
Fixed token dropdown list

### DIFF
--- a/src/app/components/CurrencyLogo/CurrencyLogo.tsx
+++ b/src/app/components/CurrencyLogo/CurrencyLogo.tsx
@@ -8,6 +8,7 @@ import { ReactComponent as SvgTokenPlaceholder } from "./token-placeholder.svg";
 const useStyles = makeStyles((theme: AppTheme) => ({
   root: {
     width: 28,
+    height: 28,
     display: "flex",
     background: "#fff",
     border: `1px solid ${theme.palette.primary.main}`,


### PR DESCRIPTION
This PR fixes two issues related to the token dropdown list:

- **Tokens should now appear in the dropdown as expected when a wallet isn't connected.**
This is done by making sure the pool is retrieved and attached to the token regardless of if a wallet is connected or not. This is now done by default during initialization.

- **Fixes an issue where the token icon height was unconstrained causing a UI glitch.**
This is done by setting a fixed height equal to the width.