### PR TITLE
Token list and icon changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "redux-saga": "^1.1.3",
     "redux-thunk": "^2.3.0",
     "uuid": "^3.3.3",
-    "validate.js": "^0.13.1"
+    "validate.js": "^0.13.1",
+    "zilswap-sdk": "^1.2.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "redux-saga": "^1.1.3",
     "redux-thunk": "^2.3.0",
     "uuid": "^3.3.3",
-    "validate.js": "^0.13.1",
-    "zilswap-sdk": "^1.2.0"
+    "validate.js": "^0.13.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/app/components/AmountLabel/AmountLabel.tsx
+++ b/src/app/components/AmountLabel/AmountLabel.tsx
@@ -11,6 +11,7 @@ import Text from "../Text";
 
 interface Props extends BoxProps {
   currency: string;
+  address: string;
   amount?: BigNumber;
   compression?: number;
   hideIcon?: boolean;
@@ -28,7 +29,7 @@ const useStyles = makeStyles((theme: AppTheme) => ({
   },
 }));
 const AmountLabel: React.FC<Props> = (props: Props) => {
-  const { children, className, amount = BIG_ZERO, currency, prefix, hideIcon = false, compression, ...rest } = props;
+  const { children, className, amount = BIG_ZERO, currency, address, prefix, hideIcon = false, compression, ...rest } = props;
   const classes = useStyles();
 
   const decimals = currency === "ZIL" ? 12 : (compression ?? 0)
@@ -36,7 +37,7 @@ const AmountLabel: React.FC<Props> = (props: Props) => {
   return (
     <Box {...rest} className={cls(classes.root, className)}>
       {!hideIcon && (
-        <CurrencyLogo className={classes.currencyLogo} currency={currency} />
+        <CurrencyLogo className={classes.currencyLogo} currency={currency} address={address} />
       )}
       <Text>{prefix}{toHumanNumber(amount.shiftedBy(-decimals))} {currency}</Text>
     </Box>

--- a/src/app/components/CurrencyDialog/components/CurrencyList/CurrencyList.tsx
+++ b/src/app/components/CurrencyDialog/components/CurrencyList/CurrencyList.tsx
@@ -99,7 +99,7 @@ const CurrencyList: React.FC<CurrencyListProps> = (props) => {
           focusRipple
           onClick={() => onSelect(token)}>
           <ContrastBox className={classes.currencyBox}>
-            <CurrencyLogo className={classes.currencyLogo} currency={token.registered && token.symbol} />
+            <CurrencyLogo className={classes.currencyLogo} currency={token.registered && token.symbol} address={token.address} />
             <Box display="flex" flexDirection="column">
               <Typography variant="h2">{token.symbol}</Typography>
 

--- a/src/app/components/CurrencyInput/CurrencyInput.tsx
+++ b/src/app/components/CurrencyInput/CurrencyInput.tsx
@@ -151,7 +151,7 @@ const CurrencyInput: React.FC<CurrencyInputProps> = (props: CurrencyInputProps) 
             {!fixedToZil && (
               <Button className={classes.currencyButton} onClick={() => setShowCurrencyDialog(true)}>
                 <Box display="flex" alignItems="center">
-                  {token && <CurrencyLogo currency={token.registered && token.symbol} className={classes.currencyLogo} />}
+                  {token && <CurrencyLogo currency={token.registered && token.symbol} address={token.address} className={classes.currencyLogo} />}
                   <Typography variant="button">{token?.symbol || "Select Token"}</Typography>
                 </Box>
                 <ExpandMoreIcon className={classes.expandIcon} />

--- a/src/app/components/CurrencyLogo/CurrencyLogo.tsx
+++ b/src/app/components/CurrencyLogo/CurrencyLogo.tsx
@@ -1,9 +1,7 @@
 import { makeStyles } from "@material-ui/core";
-import SVG from 'react-inlinesvg';
 import cls from "classnames";
 import React from "react";
 import { AppTheme } from "app/theme/types";
-import { ReactComponent as SvgTokenPlaceholder } from "./token-placeholder.svg";
 
 const useStyles = makeStyles((theme: AppTheme) => ({
   root: {
@@ -24,28 +22,32 @@ const useStyles = makeStyles((theme: AppTheme) => ({
 }));
 
 const CurrencyLogo = (props: any) => {
-  const { currency, className }: {
+  const { currency, address, className }: {
     currency: string | false;
+    address: string;
     className: string;
   } = props;
   const classes = useStyles();
   return (
     <div className={cls(classes.root, className)}>
       {
-        currency ?
-        <SVG
-          className={classes.svg}
-          src={`https://raw.githubusercontent.com/Switcheo/zilswap-token-list/master/logos/${currency}.svg`}
-          title={`${currency} Token Logo`}
-          description={`${currency} Token Logo`}
-          cacheRequests={true}
-          loader={<SvgTokenPlaceholder />}
-        >
-          <SvgTokenPlaceholder />
-        </SVG>
-        :
-        <SvgTokenPlaceholder />
+        currency === 'ZIL' ? (
+          <img 
+            className={classes.svg} 
+            src={`https://meta.viewblock.io/ZIL/logo`}
+            alt={`${currency} Token Logo`}
+            loading="lazy"
+          />
+        ) : (
+          <img 
+            className={classes.svg} 
+            src={`https://meta.viewblock.io/ZIL.${address}/logo`}
+            alt={`${currency} Token Logo`}
+            loading="lazy"
+          />
+        )
       }
+      
     </div>
   )
 };

--- a/src/app/components/PoolLogo/PoolLogo.tsx
+++ b/src/app/components/PoolLogo/PoolLogo.tsx
@@ -7,6 +7,7 @@ import CurrencyLogo from "../CurrencyLogo";
 
 interface Props extends BoxProps {
   pair: [string, string];
+  tokenAddress: string;
 }
 
 const useStyles = makeStyles((theme: AppTheme) => ({
@@ -19,14 +20,14 @@ const useStyles = makeStyles((theme: AppTheme) => ({
   },
 }));
 const PoolLogo: React.FC<Props> = (props: Props) => {
-  const { children, className, pair, ...rest } = props;
+  const { children, className, pair, tokenAddress, ...rest } = props;
   const [quote, base] = pair
   const classes = useStyles();
 
   return (
     <Box {...rest} className={cls(classes.root, className)}>
       <CurrencyLogo className={classes.baseIcon} currency={base} />
-      <CurrencyLogo currency={quote} />
+      <CurrencyLogo currency={quote} address={tokenAddress} />
     </Box>
   );
 };

--- a/src/app/components/PoolRouteIcon/PoolRouteIcon.tsx
+++ b/src/app/components/PoolRouteIcon/PoolRouteIcon.tsx
@@ -1,12 +1,13 @@
 import { Box, BoxProps } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
+import { TokenInfo } from "app/store/types";
 import { AppTheme } from "app/theme/types";
 import cls from "classnames";
 import React from "react";
 import CurrencyLogo from "../CurrencyLogo";
 
 interface Props extends BoxProps {
-  route?: string[]
+  route?: TokenInfo[]
 }
 
 const useStyles = makeStyles((theme: AppTheme) => ({
@@ -26,11 +27,12 @@ const PoolRouteIcon: React.FC<Props> = (props: Props) => {
 
   return (
     <Box {...rest} className={cls(classes.root, className)}>
-      {route.reverse().map((currency, index) => (
+      {route.reverse().map((token, index) => (
         <CurrencyLogo
           key={index}
           className={classes.icon}
-          currency={currency} />
+          currency={token.symbol}
+          address={token.address} />
       ))}
     </Box>
   );

--- a/src/app/views/main/Pool/components/PoolManage/components/PoolInfoDropdown/PoolInfoDropdown.tsx
+++ b/src/app/views/main/Pool/components/PoolManage/components/PoolInfoDropdown/PoolInfoDropdown.tsx
@@ -117,7 +117,7 @@ const PoolInfoDropdown: React.FC<Props> = (props: Props) => {
     <Box {...rest} className={cls(classes.root, className)}>
       <Button variant="text" fullWidth className={classes.buttonWrapper} onClick={onToggleDropdown}>
         <Box flex={1} display="flex" alignItems="center">
-          <PoolLogo pair={poolPair} />
+          <PoolLogo pair={poolPair} tokenAddress={token.address} />
           <Text marginLeft={1}>{poolPair.join(" - ")}</Text>
           <Box flex={1} />
           {active && <ArrowDropUpOutlined color="primary" />}
@@ -142,11 +142,13 @@ const PoolInfoDropdown: React.FC<Props> = (props: Props) => {
               justifyContent="flex-end"
               marginBottom={1}
               currency={token.symbol}
+              address={token.address}
               amount={tokenAmount}
               compression={token.decimals} />
             <AmountLabel
               justifyContent="flex-end"
               currency="ZIL"
+              address=""
               amount={zilAmount} />
             <Text variant="body2" color="textSecondary" align="right">
               ≈${toHumanNumber(depositedValue, 2)}

--- a/src/app/views/pools/PoolTransactions/components/AddRemoveLiquidityRow/AddRemoveLiquidityRow.tsx
+++ b/src/app/views/pools/PoolTransactions/components/AddRemoveLiquidityRow/AddRemoveLiquidityRow.tsx
@@ -106,7 +106,7 @@ const AddRemoveLiquidityRow: React.FC<Props> = (props: Props) => {
       </TableCell>
       <TableCell>
         <Box display="flex" alignItems="center">
-          <PoolRouteIcon route={[poolToken?.symbol, zilToken.symbol]} marginRight={1} />
+          <PoolRouteIcon route={[poolToken, zilToken]} marginRight={1} />
           <Text className={classes.text}>{poolToken?.symbol} {zilToken.symbol}</Text>
         </Box>
       </TableCell>
@@ -119,12 +119,14 @@ const AddRemoveLiquidityRow: React.FC<Props> = (props: Props) => {
           justifyContent="flex-end"
           amount={zilAmount}
           currency={zilToken.symbol}
+          address={zilToken.address}
           compression={zilToken.decimals} />
         <AmountLabel
           hideIcon
           justifyContent="flex-end"
           amount={tokenAmount}
           currency={poolToken?.symbol}
+          address={poolToken?.address}
           compression={poolToken?.decimals} />
       </TableCell>
       <TableCell align="right">

--- a/src/app/views/pools/PoolTransactions/components/SwapTxRow/SwapTxRow.tsx
+++ b/src/app/views/pools/PoolTransactions/components/SwapTxRow/SwapTxRow.tsx
@@ -53,7 +53,7 @@ const SwapTxRow: React.FC<Props> = (props: Props) => {
     inAmount,
     outAmount,
   } = React.useMemo(() => {
-    const swapRoute: string[] = [];
+    const swapRoute: TokenInfo[] = [];
 
     // in - into the contract (out of users address)
     // out - out of the contract (into the users address)
@@ -69,20 +69,20 @@ const SwapTxRow: React.FC<Props> = (props: Props) => {
     if (transaction.swap0_is_sending_zil) {
       inToken = tokenState.tokens[ZIL_TOKEN_NAME];
       outToken = tokenState.tokens[transaction.token_address];
-      swapRoute.push(inToken.symbol, outToken.symbol);
+      swapRoute.push(inToken, outToken);
       inAmount = transaction.zil_amount;
       outAmount = transaction.token_amount;
     } else {
       inToken = tokenState.tokens[transaction.token_address];
       outToken = tokenState.tokens[ZIL_TOKEN_NAME];
-      swapRoute.push(inToken.symbol, outToken.symbol);
+      swapRoute.push(inToken, outToken);
       inAmount = transaction.token_amount;
       outAmount = transaction.zil_amount;
     }
 
     if (transaction.swap1_token_address) {
       inToken = tokenState.tokens[transaction.swap1_token_address];
-      swapRoute.unshift(inToken.symbol);
+      swapRoute.unshift(inToken);
       inAmount = transaction.swap1_token_amount ?? BIG_ZERO;
     }
 
@@ -122,7 +122,7 @@ const SwapTxRow: React.FC<Props> = (props: Props) => {
       <TableCell>
         <Box display="flex" alignItems="center">
           <PoolRouteIcon route={[...swapRoute]} marginRight={1} />
-          <Text className={classes.text}>{swapRoute.join(" - ")}</Text>
+          <Text className={classes.text}>{swapRoute.map(token => token.symbol).join(" - ")}</Text>
         </Box>
       </TableCell>
       <TableCell align="right">
@@ -136,6 +136,7 @@ const SwapTxRow: React.FC<Props> = (props: Props) => {
             justifyContent="flex-end"
             amount={inAmount}
             currency={inToken.symbol}
+            address={inToken.address}
             compression={inToken.decimals} />
         )}
         {!!outToken && (
@@ -144,6 +145,7 @@ const SwapTxRow: React.FC<Props> = (props: Props) => {
             justifyContent="flex-end"
             amount={outAmount}
             currency={outToken.symbol}
+            address={outToken.address}
             compression={outToken.decimals} />
         )}
       </TableCell>

--- a/src/app/views/pools/PoolsOverview/components/PoolInfoCard/PoolInfoCard.tsx
+++ b/src/app/views/pools/PoolsOverview/components/PoolInfoCard/PoolInfoCard.tsx
@@ -177,7 +177,7 @@ const PoolInfoCard: React.FC<Props> = (props: Props) => {
     <Card {...rest} className={cls(classes.root, className)}>
       <CardContent className={classes.title}>
         <Box display="flex" alignItems="center">
-          <PoolLogo className={classes.poolIcon} pair={[token.symbol, "ZIL"]} />
+          <PoolLogo className={classes.poolIcon} pair={[token.symbol, "ZIL"]} tokenAddress={token.address} />
           <Text variant="h2">{token.symbol} - ZIL</Text>
           <Box flex={1} />
           <IconButton onClick={onShowActions} size="small">
@@ -247,6 +247,7 @@ const PoolInfoCard: React.FC<Props> = (props: Props) => {
               hideIcon
               justifyContent="flex-end"
               currency="ZIL"
+              address=""
               amount={swapVolumes[token.address]?.totalZilVolume} />
             <Text align="right" variant="body2" color="textSecondary">
               ${toHumanNumber(totalZilVolumeUSD)}
@@ -257,10 +258,12 @@ const PoolInfoCard: React.FC<Props> = (props: Props) => {
               <AmountLabel
                 marginBottom={1}
                 currency={token.symbol}
+                address={token.address}
                 amount={token.pool?.tokenReserve}
                 compression={token.decimals} />
               <AmountLabel
                 currency="ZIL"
+                address=""
                 amount={token.pool?.zilReserve} />
             </Box>
           </KeyValueDisplay>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2448,6 +2448,13 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
+async-mutex@^0.2.2:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/async-mutex/-/async-mutex-0.2.6.tgz#0d7a3deb978bc2b984d5908a2038e1ae2e54ff40"
+  integrity sha512-Hs4R+4SPgamu6rSGW8C7cV9gaWUKEHykfzCCvIRuaVv636Ju10ZdeUbvb4TBEW0INuq2DHZqXbK4Nd3yG4RaRw==
+  dependencies:
+    tslib "^2.0.0"
+
 async@^2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
@@ -2733,6 +2740,11 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.11.8, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
   integrity sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
+
+bn.js@^5.1.1:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
+  integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
 
 body-parser@1.19.0:
   version "1.19.0"
@@ -6219,6 +6231,14 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
+isomorphic-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
+  dependencies:
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.4.1"
+
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -7596,6 +7616,11 @@ node-fetch@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
   integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
+
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-forge@0.9.0:
   version "0.9.0"
@@ -11172,10 +11197,20 @@ ts-pnp@^1.1.2:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.6.tgz#389a24396d425a0d3162e96d2b4638900fdc289a"
   integrity sha512-CrG5GqAAzMT7144Cl+UIFP7mz/iIhiy+xQ6GGcnjTezhALT02uPMRw7tgDSESgB5MsfKt55+GPWw4ir1kVtMIQ==
 
+tslib@^1.11.2:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
+
+tslib@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tsutils@^3.17.1:
   version "3.17.1"
@@ -11713,6 +11748,11 @@ whatwg-fetch@^3.0.0:
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
   integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
+whatwg-fetch@^3.4.1:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
+
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
@@ -12092,3 +12132,15 @@ yargs@^7.0.0:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^5.0.0"
+
+zilswap-sdk@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/zilswap-sdk/-/zilswap-sdk-1.2.0.tgz#fa8c1c044256853fcf78e0390a922d26a612d504"
+  integrity sha512-XxoU62uGjUvsW8ft0foT+iMAokocvpDXIy7qFz0nvjkil62Tm1M+3TJtXogzg5rE/dH4cnfKgCpR134N13S1mw==
+  dependencies:
+    "@zilliqa-js/zilliqa" "^1.0.0"
+    async-mutex "^0.2.2"
+    bignumber.js "^9.0.0"
+    bn.js "^5.1.1"
+    isomorphic-fetch "^3.0.0"
+    tslib "^1.11.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2448,13 +2448,6 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
-async-mutex@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/async-mutex/-/async-mutex-0.2.2.tgz#3a9de4be23615abce7d52730b4d3a43d9258fe06"
-  integrity sha512-L1wZNK83y16khj/Fqezy+FfOp5KuywxypF/C2aYfAN3NOMLYdAVKRk3UDklqv+ngX+O+tNSEkPX+FxprxELsMA==
-  dependencies:
-    tslib "^1.11.1"
-
 async@^2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
@@ -2740,11 +2733,6 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.11.8, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
   integrity sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
-
-bn.js@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.1.tgz#48efc4031a9c4041b9c99c6941d903463ab62eb5"
-  integrity sha512-IUTD/REb78Z2eodka1QZyyEk66pciRcP6Sroka0aI3tG/iwIdYLrBD62RsubR7vqdt3WyX8p4jxeatzmRSphtA==
 
 body-parser@1.19.0:
   version "1.19.0"
@@ -6231,14 +6219,6 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
-isomorphic-fetch@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
-  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
-  dependencies:
-    node-fetch "^2.6.1"
-    whatwg-fetch "^3.4.1"
-
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -7616,11 +7596,6 @@ node-fetch@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
   integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
-
-node-fetch@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-forge@0.9.0:
   version "0.9.0"
@@ -11197,11 +11172,6 @@ ts-pnp@^1.1.2:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.6.tgz#389a24396d425a0d3162e96d2b4638900fdc289a"
   integrity sha512-CrG5GqAAzMT7144Cl+UIFP7mz/iIhiy+xQ6GGcnjTezhALT02uPMRw7tgDSESgB5MsfKt55+GPWw4ir1kVtMIQ==
 
-tslib@^1.11.1, tslib@^1.11.2:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
-  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
-
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
@@ -11743,11 +11713,6 @@ whatwg-fetch@^3.0.0:
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
   integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
-whatwg-fetch@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz#e5f871572d6879663fa5674c8f833f15a8425ab3"
-  integrity sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ==
-
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
@@ -12127,15 +12092,3 @@ yargs@^7.0.0:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^5.0.0"
-
-zilswap-sdk@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/zilswap-sdk/-/zilswap-sdk-1.2.0.tgz#fa8c1c044256853fcf78e0390a922d26a612d504"
-  integrity sha512-XxoU62uGjUvsW8ft0foT+iMAokocvpDXIy7qFz0nvjkil62Tm1M+3TJtXogzg5rE/dH4cnfKgCpR134N13S1mw==
-  dependencies:
-    "@zilliqa-js/zilliqa" "^1.0.0"
-    async-mutex "^0.2.2"
-    bignumber.js "^9.0.0"
-    bn.js "^5.1.1"
-    isomorphic-fetch "^3.0.0"
-    tslib "^1.11.2"


### PR DESCRIPTION
This changes the way the token list is displayed on ZilSwap. Registered/unregistered is removed in favour of one list showing all tokens from the default list (source: ZilStream). Every other token is reachable by entering its contract address directly.

As part of this PR this also changes the icon source of tokens to ViewBlock.