### PR TITLE
Fix/advance setting

### DIFF
--- a/src/app/components/ShowAdvanced/ShowAdvanced.tsx
+++ b/src/app/components/ShowAdvanced/ShowAdvanced.tsx
@@ -84,6 +84,7 @@ const ShowAdvanced = (props: any) => {
     if (typeof newSlippage === "number" && slippage !== newSlippage) dispatch(actions.Swap.update({ slippage: newSlippage }));
     if (typeof newExpiry === "number" && expiry !== newExpiry) dispatch(actions.Swap.update({ expiry: newExpiry }));
     toaster("Setting updated");
+    dispatch(actions.Layout.showAdvancedSetting(false))
   }
 
   const resetSetting = () => {
@@ -92,6 +93,7 @@ const ShowAdvanced = (props: any) => {
     setNewExpiry(PREFERRED_BLOCK);
     setNewSlippage(PREFERRED_SLIPPAGE);
     toaster("Setting reset");
+    dispatch(actions.Layout.showAdvancedSetting(false))
   }
 
   return (
@@ -105,7 +107,7 @@ const ShowAdvanced = (props: any) => {
       </Box>
 
       <Accordion className={classes.accordion}>
-        <AccordionSummary expandIcon={<ArrowDropDownIcon className={classes.dropDownIcon}/>}>
+        <AccordionSummary expandIcon={<ArrowDropDownIcon className={classes.dropDownIcon} />}>
           <Box display="flex" width="100%">
             <Typography>Slippage Tolerance <HelpInfo className={classes.helpInfo} placement="top" title="Set a higher slippage tolerance to ensure your transactions go through. The lower it is, the higher likelihood your transaction may fail." /></Typography>
             <Box flexGrow={1} />
@@ -118,7 +120,7 @@ const ShowAdvanced = (props: any) => {
       </Accordion>
 
       <Accordion className={classes.accordion}>
-        <AccordionSummary expandIcon={<ArrowDropDownIcon className={classes.dropDownIcon}/>}>
+        <AccordionSummary expandIcon={<ArrowDropDownIcon className={classes.dropDownIcon} />}>
           <Box display="flex" width="100%">
             <Typography>Block Expiry <HelpInfo className={classes.helpInfo} placement="top" title="Your transaction will automatically be reverted if it is PENDING beyond this number of blocks." /></Typography>
             <Box flexGrow={1} />

--- a/src/app/components/TokenGraph/TokenGraph.tsx
+++ b/src/app/components/TokenGraph/TokenGraph.tsx
@@ -341,11 +341,24 @@ const TokenGraph: React.FC<Props> = (props: Props) => {
   }
 
   const getRates = () => {
+    const rateStr = inTokenRate?.toString().split("");
+    let decPlace = 0;
+    let endCheck = false;
+    // loop through rate, if value is too small, increase the decimal place
+    rateStr?.forEach(str => {
+      if (!endCheck) {
+        if (str === "0") {
+          decPlace++;
+        } else if (str === ".") {
+        } else {
+          endCheck = true;
+        }
+      }
+    })
     if (inTokenRate) {
-      return "$" + inTokenRate.toFixed(2);
+      return "$" + inTokenRate.toFixed(3 + decPlace);
     }
     return "-";
-
   }
 
   return (
@@ -363,9 +376,9 @@ const TokenGraph: React.FC<Props> = (props: Props) => {
                 {getRates()}{` (${growth.isGreaterThan(0) ? "+" : ""}${growth.toFixed(2)}%)`}
               </Typography>
               <Typography>
-                Past 
+                Past
                 {" "}
-                { currentInterval === "15m"
+                {currentInterval === "15m"
                   ? "15 Mins"
                   : currentInterval === "1h"
                     ? "1 Hour"

--- a/src/app/store/swap/reducer.ts
+++ b/src/app/store/swap/reducer.ts
@@ -3,10 +3,13 @@ import { SwapActionTypes } from "./actions";
 import { SwapFormState } from "./types";
 import { TokenActionTypes } from "../token/actions";
 import { TokenUpdateProps, TokenUpdateAllProps } from "../token/types";
+import { LocalStorageKeys } from "app/utils/constants";
+
+const savedSlippageExpiry = JSON.parse(localStorage.getItem(LocalStorageKeys.SwapSlippageExpiry) || "{}");
 
 const initial_state: SwapFormState = {
-  slippage: 0.01, // percent
-  expiry: 3, // blocks
+  slippage: savedSlippageExpiry.slippage || 0.01, // percent
+  expiry: savedSlippageExpiry.expiry || 3, // blocks
 
   exactOf: "in",
   inAmount: new BigNumber(0),
@@ -14,6 +17,13 @@ const initial_state: SwapFormState = {
 
   isInsufficientReserves: false,
   forNetwork: null,
+}
+
+const checkToSaveSlippageExpiry = (state: SwapFormState, payload: any) => {
+  if (payload.slippage || payload.expiry) {
+    let toSave = { slippage: state.slippage, expiry: state.expiry, ...payload };
+    localStorage.setItem(LocalStorageKeys.SwapSlippageExpiry, JSON.stringify(toSave));
+  }
 }
 
 const reducer = (state: SwapFormState = initial_state, action: any) => {
@@ -32,6 +42,7 @@ const reducer = (state: SwapFormState = initial_state, action: any) => {
       };
 
     case SwapActionTypes.UPDATE:
+      checkToSaveSlippageExpiry(state, payload);
       return { ...state, ...payload };
 
     case TokenActionTypes.TOKEN_UPDATE_ALL:

--- a/src/app/utils/constants.ts
+++ b/src/app/utils/constants.ts
@@ -22,6 +22,7 @@ export const LocalStorageKeys = {
   Network: "zilswap:network",
   UserTokenList: "zilswap:user-token-list",
   PendingClaimedTxs: "zilswap:pending-claimed-txs",
+  SwapSlippageExpiry: "zilswap:swap-slippage-expiry",
 };
 
 export const PlaceholderStrings = {


### PR DESCRIPTION
changes:
- close advance setting on saving/resetting
- add persistance for the slippage and block expiry
- increase the decimals for the graph pricing
- prevent the ZilswapConnector from setting sdk to null when only zap api fails