### PR TITLE
fix/use-dynamic-mappings

### DIFF
--- a/src/app/components/ConfirmTransfer/ConfirmTransfer.tsx
+++ b/src/app/components/ConfirmTransfer/ConfirmTransfer.tsx
@@ -195,7 +195,7 @@ const ConfirmTransfer = (props: any) => {
       denom: asset.denom,
       to_address: toAddress,
       fee_address: `${BridgeParamConstants.SWTH_FEE_ADDRESS}`,
-      fee_amount: "1",
+      fee_amount: "0",
       originator: sdk.wallet?.bech32Address
     });
 
@@ -403,7 +403,7 @@ const ConfirmTransfer = (props: any) => {
   const onConfirm = async (depositAddress: string) => {
     setPending(true);
 
-    const transferFlow = BridgeParamConstants.TRANSFER_FLOW;
+    const transferFlow = bridgeState.formState.transferDirection;
     const sdk = await initTradehubSDK(swthAddrMnemonic);
     await sdk.token.reloadTokens();
     const asset = sdk.token.tokens[`${BridgeParamConstants.DEPOSIT_DENOM}`];
@@ -503,14 +503,14 @@ const ConfirmTransfer = (props: any) => {
         <Box mt={2} display="flex" justifyContent="space-between">
           <Box className={classes.networkBox} flex={1}>
             <Text variant="h4" color="textSecondary">From</Text>
-            <Text variant="h4">Ethereum Network</Text>
-            <Text variant="button">{truncate(bridgeFormState.sourceAddress, 5, 4)}</Text>
+            <Text variant="h4">{ bridgeState.formState.transferDirection === ChainTransferFlow.ETH_TO_ZIL ? 'Ethereum Network' : 'Zilliqa Network'}</Text>
+            <Text variant="button">{truncate( bridgeState.formState.sourceAddress, 5, 4)}</Text>
           </Box>
           <Box flex={0.2}></Box>
           <Box className={classes.networkBox} flex={1}>
             <Text variant="h4" color="textSecondary">To</Text>
-            <Text variant="h4">Zilliqa Network</Text>
-            <Text variant="button">{truncate(wallet?.addressInfo.bech32, 5, 4)}</Text>
+            <Text variant="h4">{ bridgeState.formState.transferDirection === ChainTransferFlow.ETH_TO_ZIL ? 'Zilliqa Network' : 'Ethereum Network'}</Text>
+            <Text variant="button">{truncate(bridgeState.formState.destAddress, 5, 4)}</Text>
           </Box>
         </Box>
       </Box>
@@ -548,36 +548,15 @@ const ConfirmTransfer = (props: any) => {
       {!complete && (
         <FancyButton
           disabled={!!pending}
-          onClick={() => {
-            const transferFlow = BridgeParamConstants.TRANSFER_FLOW;
-            if (transferFlow === ChainTransferFlow.ZIL_TO_ETH) {
-              onConfirm(bridgeFormState.destAddress!)
-            } else {
-              onConfirm(bridgeFormState.sourceAddress!)
-            }
-          }}
+          onClick={() => onConfirm(bridgeFormState.sourceAddress!)}
           variant="contained"
           color="primary"
           className={classes.actionButton}>
           {pending
             ? "Transfer in Progress..."
-            : BridgeParamConstants.TRANSFER_FLOW === ChainTransferFlow.ZIL_TO_ETH
+            : bridgeState.formState.transferDirection === ChainTransferFlow.ZIL_TO_ETH
               ? "Confirm (ZIL -> SWTH)"
               : "Confirm (ETH -> SWTH)"
-          }
-        </FancyButton>
-      )}
-
-      {!complete && (
-        <FancyButton
-          disabled={!!pending}
-          onClick={() => onWithdraw(`${bridgeFormState.sourceAddress}`)}
-          variant="contained"
-          color="primary"
-          className={classes.actionButton}>
-          {pending
-            ? "Transfer in Progress..."
-            : "Withdraw (SWTH -> ETH)"
           }
         </FancyButton>
       )}
@@ -591,7 +570,25 @@ const ConfirmTransfer = (props: any) => {
           className={classes.actionButton}>
           {pending
             ? "Transfer in Progress..."
+            : bridgeState.formState.transferDirection === ChainTransferFlow.ZIL_TO_ETH
+            ? "Withdraw (SWTH -> ETH)"
             : "Withdraw (SWTH -> ZIL)"
+          }
+        </FancyButton>
+      )}
+
+      {!complete && (
+        <FancyButton
+          disabled={!!pending}
+          onClick={() => onWithdraw(`${bridgeFormState.sourceAddress}`)}
+          variant="contained"
+          color="primary"
+          className={classes.actionButton}>
+          {pending
+            ? "Transfer in Progress..."
+            : bridgeState.formState.transferDirection === ChainTransferFlow.ZIL_TO_ETH
+            ? "Withdraw To Source (SWTH -> ZIL) (FOR TESTING)"
+            : "Withdraw To Source (SWTH -> ETH) (FOR TESTING)"
           }
         </FancyButton>
       )}

--- a/src/app/store/bridge/reducer.ts
+++ b/src/app/store/bridge/reducer.ts
@@ -1,5 +1,6 @@
 import { LocalStorageKeys } from "app/utils/constants";
 import { bnOrZero, DataCoder } from "app/utils/strings/strings";
+import { ChainTransferFlow } from "app/views/main/Bridge/components/constants";
 import BigNumber from "bignumber.js";
 import { logger } from "core/utilities";
 import { Blockchain } from "tradehub-api-js";
@@ -79,6 +80,7 @@ const initial_state: BridgeState = {
 
   formState: {
     transferAmount: new BigNumber(0),
+    transferDirection: ChainTransferFlow.ETH_TO_ZIL,
 
     isInsufficientReserves: false,
     forNetwork: null,

--- a/src/app/store/bridge/types.d.ts
+++ b/src/app/store/bridge/types.d.ts
@@ -1,4 +1,5 @@
 import { TokenInfo } from "app/store/types";
+import { ChainTransferFlow } from "app/views/main/Bridge/components/constants";
 import BigNumber from "bignumber.js";
 import dayjs from "dayjs";
 import { Blockchain } from "tradehub-api-js";
@@ -29,6 +30,7 @@ export interface BridgeFormState {
   sourceAddress?: string; // can be eth or zil address
   destAddress?: string; // can be eth or zil address
   transferAmount: BigNumber;
+  transferDirection: ChainTransferFlow;
 
   token?: TokenInfo; // might be a new DenomInfo
 

--- a/src/app/views/main/Bridge/Bridge.tsx
+++ b/src/app/views/main/Bridge/Bridge.tsx
@@ -18,6 +18,7 @@ import { ethers } from "ethers";
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Blockchain } from "tradehub-api-js";
+import { ChainTransferFlow } from "./components/constants";
 
 
 const useStyles = makeStyles((theme: AppTheme) => ({
@@ -68,8 +69,6 @@ const useStyles = makeStyles((theme: AppTheme) => ({
 }))
 
 const initialFormState = {
-  zilPrivateKey: '',
-  swthAddress: '',
   sourceAddress: '',
   destAddress: '',
   transferAmount: '0',
@@ -80,6 +79,7 @@ const BridgeView: React.FC<React.HTMLAttributes<HTMLDivElement>> = (props: any) 
   const classes = useStyles();
   const dispatch = useDispatch();
   const network = useNetwork();
+  const [ethConnectedAddress, setEthConnectedAddress] = useState('');
   const [formState, setFormState] = useState<typeof initialFormState>(initialFormState);
   const [fromBlockchain, setFromBlockchain] = useState<Blockchain.Zilliqa | Blockchain.Ethereum>(Blockchain.Ethereum);
   const [toBlockchain, setToBlockchain] = useState<Blockchain.Zilliqa | Blockchain.Ethereum>(Blockchain.Zilliqa);
@@ -91,36 +91,61 @@ const BridgeView: React.FC<React.HTMLAttributes<HTMLDivElement>> = (props: any) 
   const tokenList: 'bridge-zil' | 'bridge-eth' = fromBlockchain === Blockchain.Zilliqa ? 'bridge-zil' : 'bridge-eth'
 
   useEffect(() => {
-    // TODO: need a way to determine if updating source / dest address if the "From" is zil wallet
     if (wallet !== null) {
-      setFormState({
-        ...formState,
-        destAddress: wallet.addressInfo.byte20
-      })
-      dispatch(actions.Bridge.updateForm({
-        destAddress: wallet.addressInfo.byte20
-      }))
+      if (fromBlockchain === Blockchain.Zilliqa) {
+        setSourceAddress(wallet.addressInfo.byte20!)   
+      } else {
+        setDestAddress(wallet.addressInfo.byte20!)
+      }
     }
     // eslint-disable-next-line
-  }, [wallet]);
+  }, [wallet])
+
+  const setSourceAddress = (address: string) => {
+    setFormState({
+      ...formState,
+      sourceAddress: address
+    })
+    dispatch(actions.Bridge.updateForm({
+      sourceAddress: address
+    }))
+  }
+
+  const setDestAddress = (address: string) => {
+    setFormState({
+      ...formState,
+      destAddress: address
+    })
+    dispatch(actions.Bridge.updateForm({
+      destAddress: address
+    }))
+  }
 
   const onFromBlockchainChange = (e: React.ChangeEvent<{ name?: string | undefined; value: unknown; }>) => {
     if (e.target.value === Blockchain.Zilliqa) {
+      setSourceAddress(wallet?.addressInfo.byte20!)
       setFromBlockchain(Blockchain.Zilliqa)
       setToBlockchain(Blockchain.Ethereum)
+      setDestAddress(ethConnectedAddress)
     } else {
+      setSourceAddress(ethConnectedAddress)
       setFromBlockchain(Blockchain.Ethereum)
       setToBlockchain(Blockchain.Zilliqa)
+      setDestAddress(wallet?.addressInfo.byte20!)
     }
   }
 
   const onToBlockchainChange = (e: React.ChangeEvent<{ name?: string | undefined; value: unknown; }>) => {
     if (e.target.value === Blockchain.Zilliqa) {
+      setDestAddress(wallet?.addressInfo.byte20!)
       setToBlockchain(Blockchain.Zilliqa)
       setFromBlockchain(Blockchain.Ethereum)
+      setSourceAddress(ethConnectedAddress)
     } else {
+      setDestAddress(ethConnectedAddress)
       setToBlockchain(Blockchain.Ethereum)
       setFromBlockchain(Blockchain.Zilliqa)
+      setSourceAddress(wallet?.addressInfo.byte20!)
     }
   }
 
@@ -131,11 +156,14 @@ const BridgeView: React.FC<React.HTMLAttributes<HTMLDivElement>> = (props: any) 
       const signer = provider.getSigner();
       const ethAddress = await signer.getAddress();
 
-      setFormState({
-        ...formState,
-        sourceAddress: ethAddress
-      })
-      dispatch(actions.Bridge.updateForm({ sourceAddress: ethAddress }))
+      if (fromBlockchain === Blockchain.Ethereum) {
+        setSourceAddress(ethAddress);
+      }
+
+      if (toBlockchain === Blockchain.Ethereum) {
+        setDestAddress(ethAddress);
+      }
+      setEthConnectedAddress(ethAddress);
       dispatch(actions.Wallet.setBridgeWallet({ blockchain: Blockchain.Ethereum, address: ethAddress}))
       dispatch(actions.Token.refetchState())
     } catch (error) {
@@ -145,6 +173,14 @@ const BridgeView: React.FC<React.HTMLAttributes<HTMLDivElement>> = (props: any) 
 
   const onClickConnectZIL = () => {
     dispatch(actions.Layout.toggleShowWallet());
+
+    if (wallet !== null && fromBlockchain === Blockchain.Zilliqa) {
+      setSourceAddress(wallet.addressInfo.byte20);
+    }
+
+    if (wallet !== null && toBlockchain === Blockchain.Zilliqa) {
+      setDestAddress(wallet.addressInfo.byte20);
+    }
   };
 
   const onTransferAmountChange = (amount: string = "0") => {
@@ -173,23 +209,44 @@ const BridgeView: React.FC<React.HTMLAttributes<HTMLDivElement>> = (props: any) 
   };
 
   const showTransfer = () => {
+    if (fromBlockchain === Blockchain.Zilliqa) {
+      dispatch(actions.Bridge.updateForm({ transferDirection: ChainTransferFlow.ZIL_TO_ETH }));
+    } else {
+      dispatch(actions.Bridge.updateForm({ transferDirection: ChainTransferFlow.ETH_TO_ZIL }));
+    }
     dispatch(actions.Layout.showTransferConfirmation(!layoutState.showTransferConfirmation))
   }
 
   const getConnectEthWallet = () => {
-    return <Button
-      onClick={onClickConnectETH}
-      className={cls(classes.connectWalletButton, formState.sourceAddress ? classes.connectedWalletButton : "")}
-      variant="contained"
-      color="primary">
-      {!formState.sourceAddress
-        ? "Connect Wallet"
-        : <Box display="flex" flexDirection="column">
-          <Text variant="button">{truncate(formState.sourceAddress, 5, 4)}</Text>
-          <Text color="textSecondary"><DotIcon className={classes.dotIcon} />Connected</Text>
-        </Box>
-      }
-    </Button>
+    return (
+      fromBlockchain === Blockchain.Ethereum ?
+      <Button
+        onClick={onClickConnectETH}
+        className={cls(classes.connectWalletButton, formState.sourceAddress ? classes.connectedWalletButton : "")}
+        variant="contained"
+        color="primary">
+        {!formState.sourceAddress
+          ? "Connect Wallet"
+          : <Box display="flex" flexDirection="column">
+            <Text variant="button">{truncate(formState.sourceAddress, 5, 4)}</Text>
+            <Text color="textSecondary"><DotIcon className={classes.dotIcon} />Connected</Text>
+          </Box>
+        }
+      </Button> :
+      <Button
+        onClick={onClickConnectETH}
+        className={cls(classes.connectWalletButton, formState.destAddress ? classes.connectedWalletButton : "")}
+        variant="contained"
+        color="primary">
+        {!formState.destAddress
+          ? "Connect Wallet"
+          : <Box display="flex" flexDirection="column">
+            <Text variant="button">{truncate(formState.destAddress, 5, 4)}</Text>
+            <Text color="textSecondary"><DotIcon className={classes.dotIcon} />Connected</Text>
+          </Box>
+        }
+      </Button>
+    )
   }
 
   const getConnectZilWallet = () => {


### PR DESCRIPTION
- fixed the user selection displays under "Confirm Transfer" so that the proper source and destination network and wallet would show up
- track the transfer direction and to make the confirm flow dynamic instead of reading from constant parameters
- refactor the lock functions to return proper transaction hash or null (if the transaction fail)
- set the withdraw fee to 0