### PR TITLE
fix/address-display

### DIFF
--- a/src/app/components/ConfirmTransfer/ConfirmTransfer.tsx
+++ b/src/app/components/ConfirmTransfer/ConfirmTransfer.tsx
@@ -16,8 +16,10 @@ import { BridgeParamConstants } from "app/views/main/Bridge/components/constants
 import BigNumber from "bignumber.js";
 import cls from "classnames";
 import { logger } from "core/utilities";
+import { providerOptions } from "core/ethereum";
 import { ConnectedWallet } from "core/wallet";
 import { ethers } from "ethers";
+import Web3Modal from 'web3modal';
 import React, { useEffect, useMemo, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Blockchain, ConnectedTradeHubSDK, RestModels, SWTHAddress, TradeHubSDK } from "tradehub-api-js";
@@ -277,9 +279,16 @@ const ConfirmTransfer = (props: any) => {
     sdk.eth.configProvider.getConfig().Eth.LockProxyAddr = `0x${lockProxy}`;
     const swthAddress = sdk.wallet.bech32Address;
 
-    let provider;
-    (window as any).ethereum.enable().then(provider = new ethers.providers.Web3Provider((window as any).ethereum));
-    const signer = provider.getSigner();
+    const web3Modal = new Web3Modal({
+      network: "mainnet",
+      cacheProvider: true,
+      disableInjectedProvider: false,
+      providerOptions
+    });
+
+    const provider = await web3Modal.connect();
+    const ethersProvider = new ethers.providers.Web3Provider(provider)
+    const signer = ethersProvider.getSigner();
 
     const amount = bridgeFormState.transferAmount;
     const ethAddress = await signer.getAddress();

--- a/src/app/components/ConfirmTransfer/ConfirmTransfer.tsx
+++ b/src/app/components/ConfirmTransfer/ConfirmTransfer.tsx
@@ -9,7 +9,7 @@ import { CurrencyLogo, FancyButton, HelpInfo, KeyValueDisplay, Text } from "app/
 import { ReactComponent as NewLinkIcon } from "app/components/new_link.svg";
 import { actions } from "app/store";
 import { BridgeableToken, BridgeFormState, BridgeState, BridgeTx } from "app/store/bridge/types";
-import { RootState, WalletObservedTx } from "app/store/types";
+import { RootState } from "app/store/types";
 import { AppTheme } from "app/theme/types";
 import { hexToRGBA, truncate, useAsyncTask, useNetwork, useToaster, useTokenFinder } from "app/utils";
 import { BridgeParamConstants } from "app/views/main/Bridge/components/constants";
@@ -192,6 +192,7 @@ const ConfirmTransfer = (props: any) => {
   const classes = useStyles();
   const dispatch = useDispatch();
   const toaster = useToaster();
+  // eslint-disable-next-line
   const network = useNetwork();
   const tokenFinder = useTokenFinder();
   const [sdk, setSdk] = useState<ConnectedTradeHubSDK | null>(null);
@@ -419,22 +420,13 @@ const ConfirmTransfer = (props: any) => {
     toaster(`Locking asset (Zilliqa)`);
     const lock_tx = await sdk.zil.lockDeposit(lockDepositParams);
 
-    const walletObservedTx: WalletObservedTx = {
-      hash: lock_tx.id!,
-      deadline: Number.MAX_SAFE_INTEGER,
-      address: wallet.addressInfo.bech32 || "",
-      network,
-    };
-    dispatch(actions.Transaction.observe({ observedTx: walletObservedTx }));
     toaster(`Submitted: (Zilliqa - Lock Asset)`, { hash: lock_tx.id! });
     logger("lock tx", lock_tx.id!);
 
     return lock_tx.id;
   }
 
-  // deposit address depends on the selection
-  // not use at the moment because external wallets are used
-  const onConfirm = async (depositAddress: string) => {
+  const onConfirm = async () => {
     if (!sdk) {
       console.error("TradeHubSDK not initialized")
       return null;
@@ -759,7 +751,7 @@ const ConfirmTransfer = (props: any) => {
       {!complete && (
         <FancyButton
           disabled={loadingConfirm || !!pendingBridgeTx}
-          onClick={() => onConfirm(bridgeFormState.sourceAddress!)}
+          onClick={onConfirm}
           variant="contained"
           color="primary"
           className={classes.actionButton}>

--- a/src/app/views/main/Bridge/Bridge.tsx
+++ b/src/app/views/main/Bridge/Bridge.tsx
@@ -202,8 +202,6 @@ const BridgeView: React.FC<React.HTMLAttributes<HTMLDivElement>> = (props: any) 
   }
 
   const onFromBlockchainChange = (e: React.ChangeEvent<{ name?: string | undefined; value: unknown; }>) => {
-    console.log(e.target.value);
-    console.log(e.target);
     if (e.target.value === Blockchain.Zilliqa) {
       setSourceAddress(wallet?.addressInfo.byte20!)
       setDestAddress(ethConnectedAddress)

--- a/src/app/views/main/Bridge/Bridge.tsx
+++ b/src/app/views/main/Bridge/Bridge.tsx
@@ -178,7 +178,6 @@ const BridgeView: React.FC<React.HTMLAttributes<HTMLDivElement>> = (props: any) 
         setDestAddress(wallet.addressInfo.byte20!)
       }
     }
-
     // eslint-disable-next-line
   }, [wallet, bridgeFormState.fromBlockchain])
 
@@ -203,6 +202,8 @@ const BridgeView: React.FC<React.HTMLAttributes<HTMLDivElement>> = (props: any) 
   }
 
   const onFromBlockchainChange = (e: React.ChangeEvent<{ name?: string | undefined; value: unknown; }>) => {
+    console.log(e.target.value);
+    console.log(e.target);
     if (e.target.value === Blockchain.Zilliqa) {
       setSourceAddress(wallet?.addressInfo.byte20!)
       setDestAddress(ethConnectedAddress)
@@ -386,7 +387,7 @@ const BridgeView: React.FC<React.HTMLAttributes<HTMLDivElement>> = (props: any) 
               
               <ConnectButton
                 chain={fromBlockchain}
-                address={formState.sourceAddress}
+                address={bridgeFormState.sourceAddress || ''}
                 onClick={onConnectSrcWallet}
               />
             </Box>
@@ -416,7 +417,7 @@ const BridgeView: React.FC<React.HTMLAttributes<HTMLDivElement>> = (props: any) 
 
               <ConnectButton
                 chain={toBlockchain}
-                address={formState.destAddress}
+                address={bridgeFormState.destAddress || ''}
                 onClick={onConnectDstWallet}
               />
             </Box>


### PR DESCRIPTION
- fixed bridge address display issue; form state is updated but the display is using previously saved value
- use the web3modal to get eth signer to standardize and also  `(window as any).ethereum.enable()` is deprecated
- removed txn observer in lock asset on zil side as lock txn is observed by saga
- removed unused method arguments