### PR TITLE
Observe web3 account and network changes

### DIFF
--- a/src/app/store/wallet/actions.ts
+++ b/src/app/store/wallet/actions.ts
@@ -13,6 +13,7 @@ export function update(payload: WalletUpdateProps) {
   }
 };
 
+export type BridgeWalletAction = ReturnType<typeof setBridgeWallet>
 export function setBridgeWallet(payload: BridgeWalletUpdateProps) {
   return {
     type: WalletActionTypes.SET_BRIDGE_WALLET,

--- a/src/app/views/main/Bridge/Bridge.tsx
+++ b/src/app/views/main/Bridge/Bridge.tsx
@@ -244,7 +244,6 @@ const BridgeView: React.FC<React.HTMLAttributes<HTMLDivElement>> = (props: any) 
 
   const onClickConnectETH = async () => {
     const web3Modal = new Web3Modal({
-      network: "mainnet",
       cacheProvider: true,
       disableInjectedProvider: false,
       providerOptions
@@ -254,6 +253,7 @@ const BridgeView: React.FC<React.HTMLAttributes<HTMLDivElement>> = (props: any) 
     const ethersProvider = new ethers.providers.Web3Provider(provider)
     const signer = ethersProvider.getSigner();
     const ethAddress = await signer.getAddress();
+    const chainId = (await ethersProvider.getNetwork()).chainId;
 
     if (bridgeFormState.fromBlockchain === Blockchain.Ethereum) {
       setSourceAddress(ethAddress);
@@ -264,7 +264,7 @@ const BridgeView: React.FC<React.HTMLAttributes<HTMLDivElement>> = (props: any) 
     }
 
     setEthConnectedAddress(ethAddress);
-    dispatch(actions.Wallet.setBridgeWallet({ blockchain: Blockchain.Ethereum, wallet: { provider: provider, address: ethAddress } }));
+    dispatch(actions.Wallet.setBridgeWallet({ blockchain: Blockchain.Ethereum, wallet: { provider: provider, address: ethAddress, chainId: chainId } }));
     dispatch(actions.Token.refetchState());
   };
 

--- a/src/core/wallet/ConnectedBridgeWallet.ts
+++ b/src/core/wallet/ConnectedBridgeWallet.ts
@@ -1,4 +1,5 @@
 export type ConnectedBridgeWallet = {
   provider?: any;
   address: string;
+  chainId: number;
 }


### PR DESCRIPTION
This PR implements observers for web3 wallet account and chain changes. And adds a chainId parameter to the `ConnectedBridgeWallet` object.