### PR TITLE
Fix ZWAP rewards not loading

### DIFF
--- a/src/app/layouts/RewardsInfoButton/RewardsInfoButton.tsx
+++ b/src/app/layouts/RewardsInfoButton/RewardsInfoButton.tsx
@@ -86,6 +86,7 @@ const RewardsInfoButton: React.FC<Props> = (props: Props) => {
   const isMobileView = useMediaQuery(theme.breakpoints.down('xs'));
 
   const walletAddress = useMemo(() => walletState.wallet?.addressInfo.bech32, [walletState.wallet]);
+  const claimHistoryLoaded = useMemo(() => Object.keys(rewardsState.globalClaimHistory).length > 0, [rewardsState.globalClaimHistory])
 
   const potentialRewards = useMemo(() => {
     return Object.keys(rewardsState.potentialPoolRewards).reduce((accum, poolAddress) => {
@@ -296,8 +297,8 @@ const RewardsInfoButton: React.FC<Props> = (props: Props) => {
                 <Tooltip title={claimTooltip}>
                   <span>
                     <Button fullWidth variant="contained" color="primary" disabled={claimableRewards.isZero()} onClick={onClaimRewards} className={classes.claimRewardsButton}>
-                      {loading && <CircularProgress size="1em" color="inherit" />}
-                      {!loading && "Claim Rewards"}
+                      {(loading || !claimHistoryLoaded) && <CircularProgress size="1em" color="inherit" />}
+                      {(!loading && claimHistoryLoaded) && "Claim Rewards"}
                     </Button>
                   </span>
                 </Tooltip>

--- a/src/app/saga/app/zapSaga.ts
+++ b/src/app/saga/app/zapSaga.ts
@@ -105,6 +105,7 @@ function* queryDistribution() {
 function* queryClaimHistory() {
   while (true) {
     logger("zap saga", "query claim history");
+    let retryImmediately = false;
     try {
       const zilswap = ZilswapConnector.getSDK();
 
@@ -115,15 +116,20 @@ function* queryClaimHistory() {
 
       yield put(actions.Rewards.updateClaimHistory(globalClaimHistory));
     } catch (e) {
-      console.warn('Fetch failed, will automatically retry later. Error:')
+      retryImmediately = true;
+      console.warn('Fetch failed, will automatically retry. Error:')
       console.warn(e)
     } finally {
-      const invalidated = yield race({
-        minutePoll: delay(PollIntervals.ZWAPClaimHistory),
-        epochUpdated: take(RewardsActionTypes.UPDATE_EPOCH_INFO),
-      });
+      if (retryImmediately) {
+        yield delay(1000);
+      } else {
+        const invalidated = yield race({
+          tenMinutePoll: delay(PollIntervals.ZWAPClaimHistory),
+          epochUpdated: take(RewardsActionTypes.UPDATE_EPOCH_INFO),
+        });
 
-      logger("zap saga", "claim history invalidated", invalidated);
+        logger("zap saga", "claim history invalidated", invalidated);
+      }
     }
   }
 }

--- a/src/app/utils/constants.ts
+++ b/src/app/utils/constants.ts
@@ -78,7 +78,7 @@ export class PollIntervals {
 
   public static USDRates = 10000;
 
-  public static ZWAPClaimHistory = 60000;
+  public static ZWAPClaimHistory = 600_000;
   public static EpochInfo = 60000;
   public static PoolWeights = 3600000;
 


### PR DESCRIPTION
ZWAP rewards claim button doesn't enable until claim history is loaded from the ZilSwap DEX contract. As this history grows to a considerable size the request load time becomes longer.

- Set a more aggressive retry of loading claim history if failed.
- Set a longer delay in claim history saga (1 minute to 10 minutes) to reduce network congestion.
- Add loading indicator on claim button to inform user of background query status.